### PR TITLE
feat(browser): enhance rating display with thumbs up count fallback

### DIFF
--- a/js/civitai_browser.js
+++ b/js/civitai_browser.js
@@ -267,6 +267,16 @@ function createCivitaiCard(model) {
     const fileHash = file?.hashes?.SHA256?.toLowerCase();
     const isDownloaded = fileHash && browserState.localHashes.has(fileHash);
 
+    let ratingDisplay;
+    // 检查 rating 是否存在且为数字
+    if (version.stats && typeof version.stats.rating === 'number') {
+        ratingDisplay = `⭐ ${version.stats.rating.toFixed(1)} (${version.stats.ratingCount})`;
+    } else {
+        // 如果没有评分，尝试获取点赞数
+        const thumbs = model.stats?.thumbsUpCount || version.stats?.thumbsUpCount || 0;
+        ratingDisplay = `👍 ${thumbs}`;
+    }
+
     card.innerHTML = `
         <div class="browser-preview-container">
             <div class="browser-preview-placeholder"></div>
@@ -279,7 +289,7 @@ function createCivitaiCard(model) {
             <span class="browser-model-name" title="${model.name}">${model.name}</span>
             <span class="browser-model-creator">by ${creatorName}</span>
             <div class="browser-model-stats">
-                <span>⭐ ${version.stats.rating.toFixed(1)} (${version.stats.ratingCount})</span>
+                <span>${ratingDisplay}</span>
                 <span>⬇️ ${model.stats.downloadCount}</span>
             </div>
         </div>

--- a/js/local_manager.js
+++ b/js/local_manager.js
@@ -144,7 +144,7 @@ function createModelInfoPopup(title, model) {
                     <div class="info-item"><strong>Version:</strong> <span>${data.version_name || 'N/A'}</span></div>
                     <div class="info-item"><strong>Base Model:</strong> <span>${data.base_model || 'N/A'}</span></div>
                     <div class="info-item"><strong>Downloads:</strong> <span>${data.civitai_stats?.downloadCount || 0}</span></div>
-                    <div class="info-item"><strong>Rating:</strong> <span>${data.civitai_stats?.rating?.toFixed(1) || 'N/A'} (${data.civitai_stats?.ratingCount || 0})</span></div>
+                    <div class="info-item"><strong>Rating:</strong> <span>${(data.civitai_stats?.rating !== undefined) ? (data.civitai_stats.rating.toFixed(1) + ' (' + data.civitai_stats.ratingCount + ')') : ('👍 ' + (data.civitai_stats?.thumbsUpCount || 0))}</span></div>
                 </div>
                 <div class="info-section">
                     <h4>Tags</h4>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "civitai-toolkit"
 description ="All-in-one Civitai integration center for ComfyUI — browse online models, manage local assets,analyze community trends, and instantly apply full recipes within your workflow.（为 ComfyUI 打造的一站式 Civitai 集成中心：在线浏览模型、本地管理资源、分析社区趋势，并在工作流中即时加载完整配方。）"
-version = "4.1.1"
+version = "4.1.2"
 license = {file = "LICENSE"}
 
 [project.urls]


### PR DESCRIPTION
This pull request introduces improvements to how model ratings are displayed, ensuring that the UI gracefully handles cases where rating data may be missing by falling back to showing thumbs-up counts. Additionally, the project version is incremented to reflect these updates.

**Model rating display improvements:**

* Updated `createCivitaiCard` in `js/civitai_browser.js` to check if a numeric rating exists; if not, it displays the thumbs-up count instead, improving robustness and user experience.
* Modified the model card UI in `js/civitai_browser.js` to use the new `ratingDisplay` logic, ensuring consistent and informative stats presentation.
* Enhanced the info popup in `js/local_manager.js` to show either the rating (with count) or the thumbs-up count if rating is unavailable, making model info more reliable.

**Version update:**

* Bumped the project version from `4.1.1` to `4.1.2` in `pyproject.toml` to reflect these changes.